### PR TITLE
Require `random >= 1.3`

### DIFF
--- a/bloomfilter-blocked.cabal
+++ b/bloomfilter-blocked.cabal
@@ -154,7 +154,7 @@ test-suite fpr-calc
     , bloomfilter-blocked
     , containers
     , parallel
-    , random
+    , random               >=1.3
     , regression-simple
 
   ghc-options:    -threaded -rtsopts


### PR DESCRIPTION
Resolves https://github.com/IntersectMBO/lsm-tree/issues/797